### PR TITLE
Limited Hud - Mappin Compatibility Changes

### DIFF
--- a/src/Limited HUD/r6/scripts/LHUD/core/mappinsChecker.reds
+++ b/src/Limited HUD/r6/scripts/LHUD/core/mappinsChecker.reds
@@ -82,6 +82,7 @@ public class MappinChecker {
       || Equals(variant, gamedataMappinVariant.Zzz16_RelicDeviceSpecialVariant)
       || Equals(variant, gamedataMappinVariant.Zzz17_NCARTVariant)
       || Equals(variant, gamedataMappinVariant.Zzz18_RacingVariant)
+      || Equals(variant, gamedataMappinVariant.CPO_PingLootVariant)
       || false;
   }
 

--- a/src/Limited HUD/r6/scripts/LHUD/modules/worldMarkersQuest.reds
+++ b/src/Limited HUD/r6/scripts/LHUD/modules/worldMarkersQuest.reds
@@ -16,7 +16,7 @@ protected cb func OnLHUDEvent(evt: ref<LHUDEvent>) -> Void {
 }
 
 @addMethod(QuestMappinController)
-public func DetermineCurrentVisibility() -> Void {
+public func DetermineCurrentVisibility() -> Bool {
   // -- Default conditions
   let isInQuestArea: Bool = this.m_questMappin != null && this.m_questMappin.IsInsideTrigger();
   let showWhenClamped: Bool = this.isCurrentlyClamped ? !this.m_shouldHideWhenClamped : true;
@@ -38,7 +38,7 @@ public func DetermineCurrentVisibility() -> Void {
     let isVisible: Bool = showIfTracked || showForGlobalHotkey || showForCombat || showForOutOfCombat || showForStealth || showForVehicle || showForAutoDrive || showForScanner || showForWeapon || showForZoom || showForArea;
     this.lhud_isVisibleNow = shouldBeVisible && isVisible;
     this.SetRootVisible(this.lhud_isVisibleNow);
-    return ;
+    return true;
   };
   // ---- Loot
   if this.lhudConfigLoot.IsEnabled && MappinChecker.IsLootMarker(this.m_mappin) {
@@ -55,7 +55,7 @@ public func DetermineCurrentVisibility() -> Void {
     let isVisible: Bool = showForGlobalHotkey || showForCombat || showForOutOfCombat || showForStealth || showForVehicle || showForAutoDrive || showForScanner || showForWeapon || showForZoom || showForArea;
     this.lhud_isVisibleNow = shouldBeVisible && isVisible;
     this.SetRootVisible(this.lhud_isVisibleNow);
-    return ;
+    return true;
   };
   // ---- Vehicles
   if this.lhudConfigVehicles.IsEnabled && MappinChecker.IsVehicleIcon(this.m_mappin) {
@@ -68,7 +68,7 @@ public func DetermineCurrentVisibility() -> Void {
     let isVisible: Bool = showForGlobalHotkey || showForVehicle || showForAutoDrive || showForScanner || showForZoom || showForArea;
     this.lhud_isVisibleNow = shouldBeVisible && isVisible && !this.lhud_isBraindanceActive;
     this.SetRootVisible(this.lhud_isVisibleNow);
-    return ;
+    return true;
   };
   // ---- POIs
   if this.lhudConfigPOI.IsEnabled && MappinChecker.IsPlaceOfInterestIcon(this.m_mappin) {
@@ -86,7 +86,7 @@ public func DetermineCurrentVisibility() -> Void {
     let isVisible: Bool = showIfTracked || showForGlobalHotkey || showForCombat || showForOutOfCombat || showForStealth || showForVehicle || showForAutoDrive || showForScanner || showForWeapon || showForZoom || showForArea;
     this.lhud_isVisibleNow = shouldBeVisible && isVisible && !this.lhud_isBraindanceActive;
     this.SetRootVisible(this.lhud_isVisibleNow);
-    return ;
+    return true;
   };
   // ---- Combat
   if this.lhudConfigCombat.IsEnabled && MappinChecker.IsCombatMarker(this.m_mappin) {
@@ -102,7 +102,7 @@ public func DetermineCurrentVisibility() -> Void {
     let isVisible: Bool = showForGlobalHotkey || showForCombat || showForOutOfCombat || showForStealth || showForVehicle || showForScanner || showForWeapon || showForZoom || showForArea;
     this.lhud_isVisibleNow = shouldBeVisible && isVisible;
     this.SetRootVisible(this.lhud_isVisibleNow);
-    return ;
+    return true;
   };
   // ---- Devices and interactions
   if this.lhudConfigDevices.IsEnabled && MappinChecker.IsDeviceInteraction(this.m_mappin) {
@@ -110,13 +110,12 @@ public func DetermineCurrentVisibility() -> Void {
     let isVisible: Bool = showForScanner && shouldBeVisible;
     this.lhud_isVisibleNow = isVisible;
     this.SetRootVisible(this.lhud_isVisibleNow);
-    return ;
+    return true;
   };
 
-  this.lhud_isVisibleNow = shouldBeVisible;
-  this.SetRootVisible(shouldBeVisible);
-  let data: ref<GameplayRoleMappinData> = this.m_mappin.GetScriptData() as GameplayRoleMappinData;
-  LHUDLogMarker(s"MISSED MAPPIN: \(this.m_mappin.GetVariant()), role: \(data.m_gameplayRole), visibility \(this.lhud_isVisibleNow)");
+  // let data: ref<GameplayRoleMappinData> = this.m_mappin.GetScriptData() as GameplayRoleMappinData;
+  // LHUDLogMarker(s"MISSED MAPPIN: \(this.m_mappin.GetVariant()), role: \(data.m_gameplayRole), visibility \(this.lhud_isVisibleNow)");
+  return false;
 }
 
 @addField(QuestMappinController) private let lhudConfigQuest: ref<WorldMarkersModuleConfigQuest>;
@@ -139,14 +138,20 @@ protected cb func OnInitialize() -> Bool {
   this.DetermineCurrentVisibility();
 }
 
-@replaceMethod(QuestMappinController)
+@wrapMethod(QuestMappinController)
 private func UpdateVisibility() -> Void {
-  this.DetermineCurrentVisibility();
+  if !this.DetermineCurrentVisibility() {
+    wrappedMethod();
+    this.lhud_isVisibleNow = this.GetRootWidget().IsVisible();
+  }
 }
 
-@replaceMethod(GameplayMappinController)
+@wrapMethod(GameplayMappinController)
 private func UpdateVisibility() -> Void {
-  this.DetermineCurrentVisibility();
+  if !this.DetermineCurrentVisibility() {
+    wrappedMethod();
+    this.lhud_isVisibleNow = this.GetRootWidget().IsVisible();
+  }
 }
 
 @addMethod(QuestMappinController)

--- a/src/Limited HUD/r6/scripts/LHUD/modules/worldMarkersQuest.reds
+++ b/src/Limited HUD/r6/scripts/LHUD/modules/worldMarkersQuest.reds
@@ -15,12 +15,34 @@ protected cb func OnLHUDEvent(evt: ref<LHUDEvent>) -> Void {
   this.DetermineCurrentVisibility();
 }
 
+@if(!ModuleExists("DisclosedHiddenGems.Core"))
 @addMethod(QuestMappinController)
-public func DetermineCurrentVisibility() -> Bool {
-  // -- Default conditions
+public func ShouldMappinBeVisible() -> Bool {
   let isInQuestArea: Bool = this.m_questMappin != null && this.m_questMappin.IsInsideTrigger();
   let showWhenClamped: Bool = this.isCurrentlyClamped ? !this.m_shouldHideWhenClamped : true;
   let shouldBeVisible: Bool = this.m_mappin.IsVisible() && showWhenClamped && !isInQuestArea;
+
+  return shouldBeVisible;
+}
+
+@if(ModuleExists("DisclosedHiddenGems.Core"))
+@addMethod(QuestMappinController)
+public func ShouldMappinBeVisible() -> Bool {
+  let isInQuestArea: Bool = this.m_questMappin != null && this.m_questMappin.IsInsideTrigger();
+  let showWhenClamped: Bool = this.isCurrentlyClamped ? !this.m_shouldHideWhenClamped : true;
+  let shouldBeVisible: Bool = this.m_mappin.IsVisible() && showWhenClamped && !isInQuestArea;
+
+  if this.IsHiddenGem() {
+    return this.ShouldHiddenGemMappinBeVisible() && shouldBeVisible;
+  } else {
+    return shouldBeVisible;
+  }
+}
+
+@addMethod(QuestMappinController)
+public func DetermineCurrentVisibility() -> Bool {
+  // -- Default conditions
+  let shouldBeVisible: Bool = this.ShouldMappinBeVisible();
   // -- LHUD Conditions
   // ---- Quests
   if this.lhudConfigQuest.IsEnabled && MappinChecker.IsQuestIcon(this.m_mappin) {


### PR DESCRIPTION
these changes help LHUD be more compatible with my mod. in my mod, i add custom markers under the `CPO_PingLootVariant` variant as from what i see, it isn't used in vanilla and is most likely left over of when the devs was making a multiplayer feature.

**1.** the first change done was adding `CPO_PingLootVariant` to the method `MappinChecker#IsPlaceOfInterestIcon`, so markers added by my mod would make LHUD consider those mappins as points of interests.

**2.** the changes to the file `worldMarkersQuest` prevent both of our mods overwriting the other when updating visibility for mappins (assuming that module is disabled in LHUD). this was done so that if POIs are enabled in LHUD, it will be responsible for visibility, otherwise my mod will manage it.

the main change is to the `DetermineCurrentVisibility` method, where it will return a boolean to determine whether if the mappin's visibility has been set (as in, whether if the respective module is enabled in options). before, it'll go through the conditions and if none are true, it will set the visiblity. on its own, this isn't an issue but since this method is also called in `OnLHUDEvent`, it may override the visibility expected by my mod.

to prevent this, the fall-through case of setting visibility when no condition is true was removed and opted instead to wrap the respective `UpdateVisibility` methods. there it will call `DetermineCurrentVisibility` and if false, it will call the original method.

of course please feel free to test it out and change if needed.